### PR TITLE
feat: update ml-peak-shape-generator to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "assign-deep": "^1.0.1",
     "ml-array-max": "^1.2.2",
     "ml-levenberg-marquardt": "^3.1.0",
-    "ml-peak-shape-generator": "^1.0.0"
+    "ml-peak-shape-generator": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "pseudovoigt"
   ],
   "author": "Andres Castillo",
+  "contributors": [
+    "J. Alejandro Bolaños A. <jobo322>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mljs/spectra-fitting/issues"
@@ -61,6 +64,6 @@
     "assign-deep": "^1.0.1",
     "ml-array-max": "^1.2.2",
     "ml-levenberg-marquardt": "^3.1.0",
-    "ml-peak-shape-generator": "^2.0.1"
+    "ml-peak-shape-generator": "^2.0.2"
   }
 }

--- a/src/shapes/sumOfGaussianLorentzians.js
+++ b/src/shapes/sumOfGaussianLorentzians.js
@@ -1,5 +1,6 @@
-import { PseudoVoigt } from 'ml-peak-shape-generator';
+import { pseudoVoigt } from 'ml-peak-shape-generator';
 
+const { fct: pseudoVoigtFct } = pseudoVoigt;
 /**
  * This function calculates the spectrum as a sum of linear combination of gaussian and lorentzian functions. The pseudo voigt
  * parameters are divided in 4 batches. 1st: centers; 2nd: heights; 3th: widths; 4th: mu's ;
@@ -14,7 +15,7 @@ export function sumOfGaussianLorentzians(p) {
     let result = 0;
     for (let i = 0; i < nL; i++) {
       result +=
-        p[i + nL] * PseudoVoigt.fct(t - p[i], p[i + nL * 2], p[i + nL * 3]);
+        p[i + nL] * pseudoVoigtFct(t - p[i], p[i + nL * 2], p[i + nL * 3]);
     }
     return result;
   };

--- a/src/shapes/sumOfGaussians.js
+++ b/src/shapes/sumOfGaussians.js
@@ -1,4 +1,6 @@
-import { Gaussian } from 'ml-peak-shape-generator';
+import { gaussian } from 'ml-peak-shape-generator';
+
+const { fct: gaussianFct } = gaussian;
 /**
  * This function calculates the spectrum as a sum of gaussian functions. The Gaussian
  * parameters are divided in 3 batches. 1st: centers; 2nd: height; 3th: widths;
@@ -12,7 +14,7 @@ export function sumOfGaussians(p) {
     let nL = p.length / 3;
     let result = 0;
     for (let i = 0; i < nL; i++) {
-      result += p[i + nL] * Gaussian.fct(t - p[i], p[i + nL * 2]);
+      result += p[i + nL] * gaussianFct(t - p[i], p[i + nL * 2]);
     }
     return result;
   };

--- a/src/shapes/sumOfLorentzians.js
+++ b/src/shapes/sumOfLorentzians.js
@@ -1,5 +1,6 @@
-import { Lorentzian } from 'ml-peak-shape-generator';
+import { lorentzian } from 'ml-peak-shape-generator';
 
+const { fct: lorentzianFct } = lorentzian;
 /**
  * This function calculates the spectrum as a sum of lorentzian functions. The Lorentzian
  * parameters are divided in 3 batches. 1st: centers; 2nd: heights; 3th: widths;
@@ -13,7 +14,7 @@ export function sumOfLorentzians(p) {
     let nL = p.length / 3;
     let result = 0;
     for (let i = 0; i < nL; i++) {
-      result += p[i + nL] * Lorentzian.fct(t - p[i], p[i + nL * 2]);
+      result += p[i + nL] * lorentzianFct(t - p[i], p[i + nL * 2]);
     }
     return result;
   };


### PR DESCRIPTION
Locally, I am getting eslint errors with respect to ml-peak-shape-generator

![image](https://user-images.githubusercontent.com/12143935/128833941-1154c4c5-3633-41ad-a0d5-10c42c44c6ef.png)