### PR TITLE
fix: export options interfaces

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,1 @@
 extends: cheminfo-typescript
-parserOptions:
-  sourceType: module

--- a/.github/workflows/lactame.yml
+++ b/.github/workflows/lactame.yml
@@ -5,16 +5,16 @@ on:
     types: [published]
 
 env:
-  NODE_VERSION: 14.x
+  NODE_VERSION: 16.x
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get package name
         run: echo "PACKAGE_NAME=$(jq .name package.json | tr -d '"')" >> $GITHUB_ENV
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies

--- a/.github/workflows/nodejs-ts.yml
+++ b/.github/workflows/nodejs-ts.yml
@@ -11,5 +11,5 @@ jobs:
     # Documentation: https://github.com/zakodium/workflows#nodejs-ci
     uses: zakodium/workflows/.github/workflows/nodejs.yml@nodejs-v1
     with:
-      node-version-matrix: '[12, 14, 16]'
+      node-version-matrix: '[12, 14, 16, 18]'
       lint-check-types: true

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -13,8 +13,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['@babel/preset-typescript'],
+  plugins: ['@babel/plugin-transform-modules-commonjs'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: 'ts-jest/presets/js-with-ts',
-  testEnvironment: 'node',
-};

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "homepage": "https://github.com/mljs/spectra-fitting",
   "devDependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.17.9",
     "@babel/preset-typescript": "^7.16.7",
     "@types/jest": "^27.4.1",
     "cheminfo-build": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
     "test": "npm run test-only && npm run eslint && npm run check-types",
     "prettier": "prettier --check src",
     "prettier-write": "prettier --write src",
-    "test-coverage": "jest --coverage",
-    "test-only": "jest --coverage --silent=false",
-    "tsc": "npm run clean && npm run tsc-cjs && npm run tsc-esm",
+    "test-only": "jest --coverage",
+    "tsc": "npm run clean && npm iun tsc-cjs && npm run tsc-esm",
     "tsc-cjs": "tsc --project tsconfig.cjs.json",
     "tsc-esm": "tsc --project tsconfig.esm.json",
     "debug": "npm run prepublishOnly && node src/debug.js"
@@ -47,19 +46,16 @@
   },
   "homepage": "https://github.com/mljs/spectra-fitting",
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.16.8",
+    "@babel/preset-typescript": "^7.16.7",
     "@types/jest": "^27.4.1",
     "cheminfo-build": "^1.1.11",
-    "eslint": "^8.10.0",
-    "eslint-config-cheminfo": "^7.2.2",
-    "eslint-config-cheminfo-typescript": "^10.3.0",
-    "esm": "^3.2.25",
-    "jest": "^27.5.1",
+    "eslint": "^8.14.0",
+    "eslint-config-cheminfo-typescript": "^10.4.0",
+    "jest": "^28.0.0",
     "jest-matcher-deep-close-to": "^3.0.2",
-    "prettier": "^2.5.1",
+    "prettier": "^2.6.2",
     "spectrum-generator": "^7.0.1",
-    "ts-jest": "^27.1.3",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.3"
   },
   "dependencies": {
     "cheminfo-types": "^1.1.0",

--- a/src/spectra-fitting.ts
+++ b/src/spectra-fitting.ts
@@ -41,19 +41,3 @@ export interface Peak1D {
   fwhm: number;
   shape?: Shape1D;
 }
-
-export interface OptimizationOptions {
-  kind?: string | number;
-  parameters?: any;
-  options?: {
-    timeout?: number;
-    damping?: number;
-    maxIterations?: number;
-    errorTolerance?: number;
-  };
-}
-
-export interface OptimizeOptions {
-  shape?: Shape1D | { kind: string };
-  optimization?: OptimizationOptions;
-}

--- a/src/util/checkInput.ts
+++ b/src/util/checkInput.ts
@@ -2,8 +2,9 @@ import { DataXY, DoubleArray } from 'cheminfo-types';
 import getMaxValue from 'ml-array-max';
 import { Shape1D } from 'ml-peak-shape-generator';
 
+import { OptimizeOptions } from '..';
 import { getSumOfShapes } from '../shapes/getSumOfShapes';
-import { OptimizeOptions, Peak1D } from '../spectra-fitting';
+import { Peak1D } from '../spectra-fitting';
 
 import { assignDeep } from './assignDeep';
 
@@ -171,8 +172,6 @@ export function checkInput(
     }
   }
 
-  optimization.parameters = parameters;
-
   return {
     y,
     x,
@@ -180,6 +179,6 @@ export function checkInput(
     minY,
     peaks,
     sumOfShapes,
-    optimization,
+    optimization: { ...optimization, parameters },
   };
 }

--- a/src/util/selectMethod.ts
+++ b/src/util/selectMethod.ts
@@ -1,8 +1,8 @@
 import { levenbergMarquardt } from 'ml-levenberg-marquardt';
 
-import { OptimizationOptions } from '../spectra-fitting';
+import { OptimizationOptions } from '..';
 
-const LEVENBERG_MARQUARDT = 1;
+const LEVENBERG_MARQUARDT = 'LEVENBERG_MARQUARDT';
 
 /** Algorithm to select the method.
  * @param optimizationOptions - Optimization options
@@ -39,8 +39,7 @@ function checkOptions(
   }
 }
 
-function getKind(kind?: string | number) {
-  if (typeof kind !== 'string') return kind;
+function getKind(kind = '') {
   switch (kind.toLowerCase().replace(/[^a-z]/g, '')) {
     case 'lm':
     case 'levenbergmarquardt':


### PR DESCRIPTION
They were lost when the project migrated to TypeScript and it breaks
ml-gsd type linting.
