### PR TITLE
fix: improve scaling of y

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,10 @@ export interface OptimizationOptions {
 
 export interface OptimizeOptions {
   /**
+   * baseline value to shift the intensity of data and peak
+   */
+  baseline?: number;
+  /**
    * Kind of shape used for fitting.
    **/
   shape?: Shape1D;
@@ -98,12 +102,16 @@ export function optimize(
   iterations: number;
 } {
   // rescale data
-  const minMaxY = getMinMaxY(data.y);
+  let temp = xMinMaxValues(data.y);
+  const minMaxY = { ...temp, range: temp.max - temp.min };
+
   const internalPeaks = getInternalPeaks(peaks, minMaxY, options);
+
   // need to rescale what is related to Y
+  const { baseline: shiftValue = minMaxY.min } = options;
   let normalizedY = new Float64Array(data.y.length);
   for (let i = 0; i < data.y.length; i++) {
-    normalizedY[i] = data.y[i] / minMaxY.maxAbsoluteY;
+    normalizedY[i] = (data.y[i] - shiftValue) / minMaxY.range;
   }
 
   const nbParams = internalPeaks[internalPeaks.length - 1].toIndex + 1;
@@ -121,7 +129,6 @@ export function optimize(
       index++;
     }
   }
-
   let { algorithm, optimizationOptions } = selectMethod(options.optimization);
 
   let sumOfShapes = getSumOfShapes(internalPeaks);
@@ -134,6 +141,7 @@ export function optimize(
     ...optimizationOptions,
   });
   const fittedValues = fitted.parameterValues;
+
   let newPeaks: OptimizedPeak[] = [];
   for (let peak of internalPeaks) {
     const newPeak = {
@@ -142,7 +150,7 @@ export function optimize(
       shape: peak.shape,
     };
     newPeak.x = fittedValues[peak.fromIndex];
-    newPeak.y = fittedValues[peak.fromIndex + 1] * minMaxY.maxAbsoluteY;
+    newPeak.y = fittedValues[peak.fromIndex + 1] * minMaxY.range + shiftValue;
     for (let i = 2; i < peak.parameters.length; i++) {
       //@ts-expect-error should be fixed once
       newPeak.shape[peak.parameters[i]] = fittedValues[peak.fromIndex + i];
@@ -155,15 +163,5 @@ export function optimize(
     error: fitted.parameterError,
     iterations: fitted.iterations,
     peaks: newPeaks,
-  };
-}
-
-function getMinMaxY(data: DoubleArray) {
-  const { min, max } = xMinMaxValues(data);
-  return {
-    min,
-    max,
-    maxAbsoluteY: Math.abs(-min > max ? min : max),
-    range: max - min,
   };
 }

--- a/src/util/internalPeaks/DefaultParameters.ts
+++ b/src/util/internalPeaks/DefaultParameters.ts
@@ -14,8 +14,8 @@ export const DefaultParameters = {
   },
   y: {
     init: (peak: Peak) => peak.y,
-    min: (peak: Peak) => (peak.y < 1 ? -1.1 : 0),
-    max: (peak: Peak) => (peak.y < 1 ? 0 : 1.1),
+    min: (peak: Peak) => (peak.y < 0 ? -1.1 : 0),
+    max: (peak: Peak) => (peak.y < 0 ? 0 : 1.1),
     gradientDifference: () => 1e-3,
   },
   fwhm: {

--- a/src/util/internalPeaks/DefaultParameters.ts
+++ b/src/util/internalPeaks/DefaultParameters.ts
@@ -14,8 +14,8 @@ export const DefaultParameters = {
   },
   y: {
     init: (peak: Peak) => peak.y,
-    min: () => 0,
-    max: () => 1.5,
+    min: (peak: Peak) => (peak.y < 1 ? -1.1 : 0),
+    max: (peak: Peak) => (peak.y < 1 ? 0 : 1.1),
     gradientDifference: () => 1e-3,
   },
   fwhm: {

--- a/src/util/internalPeaks/__tests__/getInternalPeaks.test.ts
+++ b/src/util/internalPeaks/__tests__/getInternalPeaks.test.ts
@@ -16,7 +16,7 @@ describe('getInternalPeaks', () => {
         parameters: ['x', 'y', 'fwhm'],
         propertiesValues: {
           min: [-1000, 0, 125],
-          max: [1000, 1.5, 2000],
+          max: [1000, 1.1, 2000],
           init: [0, 1, 500],
           gradientDifference: [1, 0.001, 1],
         },
@@ -39,7 +39,7 @@ describe('getInternalPeaks', () => {
       parameters: ['x', 'y', 'fwhm', 'mu'],
       propertiesValues: {
         min: [-999, 0, 125, 0],
-        max: [1001, 1.5, 2000, 1],
+        max: [1001, 1.1, 2000, 1],
         init: [1, 2, 500, 0.5],
         gradientDifference: [1, 0.001, 1, 0.01],
       },
@@ -64,7 +64,7 @@ describe('getInternalPeaks', () => {
         parameters: ['x', 'y', 'fwhm'],
         propertiesValues: {
           min: [-1000, 0, 125],
-          max: [1000, 1.5, 2000],
+          max: [1000, 1.1, 2000],
           init: [0, 1, 500],
           gradientDifference: [1, 0.001, 1],
         },
@@ -94,7 +94,7 @@ describe('getInternalPeaks', () => {
         parameters: ['x', 'y', 'fwhm'],
         propertiesValues: {
           min: [-1, -2, 125],
-          max: [1, 1.5, 2000],
+          max: [1, 1.1, 2000],
           init: [0, 1, 500],
           gradientDifference: [1, 0.001, 1],
         },

--- a/src/util/internalPeaks/getInternalPeaks.ts
+++ b/src/util/internalPeaks/getInternalPeaks.ts
@@ -26,7 +26,7 @@ export interface InternalPeak {
  */
 export function getInternalPeaks(
   peaks: Peak[],
-  minMaxY: { min: number; max: number; range: number },
+  minMaxY: { min: number; max: number; range: number, maxAbsoluteY: number },
   options: OptimizeOptions = {},
 ) {
   let index = 0;
@@ -118,13 +118,13 @@ function getNormalizedValue(
   value: number,
   parameter: string,
   property: string,
-  minMaxY: { min: number; max: number; range: number },
+  minMaxY: { min: number; max: number; range: number, maxAbsoluteY: number },
 ): number {
   if (parameter === 'y') {
     if (property === 'gradientDifference') {
       return value;
     } else {
-      return value / minMaxY.max;
+      return value / minMaxY.maxAbsoluteY;
     }
   }
   return value;

--- a/src/util/internalPeaks/getInternalPeaks.ts
+++ b/src/util/internalPeaks/getInternalPeaks.ts
@@ -122,9 +122,9 @@ function getNormalizedValue(
 ): number {
   if (parameter === 'y') {
     if (property === 'gradientDifference') {
-      return value / minMaxY.range;
+      return value;
     } else {
-      return (value - minMaxY.min) / minMaxY.range;
+      return value / minMaxY.max;
     }
   }
   return value;

--- a/src/util/internalPeaks/getInternalPeaks.ts
+++ b/src/util/internalPeaks/getInternalPeaks.ts
@@ -26,12 +26,21 @@ export interface InternalPeak {
  */
 export function getInternalPeaks(
   peaks: Peak[],
-  minMaxY: { min: number; max: number; range: number, maxAbsoluteY: number },
+  minMaxY: { min: number; max: number; range: number },
   options: OptimizeOptions = {},
 ) {
   let index = 0;
   let internalPeaks: InternalPeak[] = [];
-  for (const peak of peaks) {
+  const { baseline: shiftValue = minMaxY.min } = options;
+
+  const normalizedPeaks = peaks.map((peak) => {
+    return {
+      ...peak,
+      y: (peak.y - shiftValue) / minMaxY.range,
+    };
+  });
+
+  for (const peak of normalizedPeaks) {
     const shape: Shape1D = peak.shape
       ? peak.shape
       : options.shape
@@ -60,6 +69,7 @@ export function getInternalPeaks(
             parameter,
             property,
             minMaxY,
+            options.baseline,
           );
 
           propertiesValues[property].push(propertyValue);
@@ -76,12 +86,19 @@ export function getInternalPeaks(
               parameter,
               property,
               minMaxY,
+              options.baseline,
             );
             propertiesValues[property].push(generalParameterValue);
             continue;
           } else {
             let value = generalParameterValue(peak);
-            value = getNormalizedValue(value, parameter, property, minMaxY);
+            value = getNormalizedValue(
+              value,
+              parameter,
+              property,
+              minMaxY,
+              options.baseline,
+            );
             propertiesValues[property].push(value);
             continue;
           }
@@ -118,13 +135,16 @@ function getNormalizedValue(
   value: number,
   parameter: string,
   property: string,
-  minMaxY: { min: number; max: number; range: number, maxAbsoluteY: number },
+  minMaxY: { min: number; max: number; range: number },
+  baseline?: number,
 ): number {
   if (parameter === 'y') {
     if (property === 'gradientDifference') {
       return value;
     } else {
-      return value / minMaxY.maxAbsoluteY;
+      return baseline !== undefined
+        ? (value - baseline) / minMaxY.range
+        : (value - minMaxY.min) / minMaxY.range;
     }
   }
   return value;


### PR DESCRIPTION
The current behavior assumes that the min value of `y` is the baseline so it scales between 0-1. It is not always correct because we could pass a fraction of the shape or data with positive and negative peaks. So the Idea is to keep the current behavior and add the option `baseline` so we can define a value (number). 

- Setting a baseline equal to zero by default does not produce better results.
- In the case of a baseline different than the min value of the data. The optimized value of the parameter `y` is the closest to the input data (optimal). So to draw correctly the reconstructed spectra, we should scale the `y` parameter, then generate the spectrum with a baseline equal to zero, then shift the spectrum to the right baseline.
```js
const shiftedPeaks = optimizedPeaks.map((peak) =>  peak.y - baseline);
const spectrum = generateSpectrum(peaks);
const shiftedSpectrum = xAdd(spectrum, baseline);
```

close #95 #84